### PR TITLE
base64 support

### DIFF
--- a/src/ServiceStack.Text/Common/DeserializeSpecializedCollections.cs
+++ b/src/ServiceStack.Text/Common/DeserializeSpecializedCollections.cs
@@ -49,7 +49,7 @@ namespace ServiceStack.Text.Common
 #if !SILVERLIGHT
 			if (typeof(T) == typeof(StringCollection))
 			{
-				return ParseStringCollection<TSerializer>;
+				return ParseStringCollection;
 			}
 #endif
 
@@ -69,7 +69,7 @@ namespace ServiceStack.Text.Common
 		}
 
 #if !SILVERLIGHT
-		public static StringCollection ParseStringCollection<TSerializer>(string value) where TSerializer : ITypeSerializer
+		public static StringCollection ParseStringCollection(string value)
 		{
 			if ((value = DeserializeListWithElements<TSerializer>.StripList(value)) == null) return null;
 			return value == String.Empty

--- a/src/ServiceStack.Text/ServiceStack.Text.csproj
+++ b/src/ServiceStack.Text/ServiceStack.Text.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <VersionPrefix>3.7.3</VersionPrefix>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.1</TargetFrameworks>
     <AssemblyName>ServiceStack.Text</AssemblyName>
     <PackageId>ServiceStack.Text-Scopely</PackageId>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard2.1' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -33,11 +33,11 @@
     <Reference Include="System" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <DefineConstants>$(DefineConstants);CORE_CLR</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="System.Collections.NonGeneric" Version="4.0.1" />
     <PackageReference Include="System.Collections.Specialized" Version="4.0.1" />
     <PackageReference Include="System.Reflection" Version="4.1.0" />

--- a/src/ServiceStack.Text/ServiceStack.Text.csproj
+++ b/src/ServiceStack.Text/ServiceStack.Text.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.7.3</VersionPrefix>
+    <VersionPrefix>3.8.0</VersionPrefix>
     <TargetFrameworks>net45;netstandard2.1</TargetFrameworks>
     <AssemblyName>ServiceStack.Text</AssemblyName>
     <PackageId>ServiceStack.Text-Scopely</PackageId>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard2.1' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -14,7 +12,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <Version>3.7.3</Version>
+    <Version>3.8.0</Version>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
@@ -38,16 +36,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="System.Collections.NonGeneric" Version="4.0.1" />
-    <PackageReference Include="System.Collections.Specialized" Version="4.0.1" />
-    <PackageReference Include="System.Reflection" Version="4.1.0" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.0.1" />
-    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.0.1" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.0.1" />
-    <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
-    <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.0.0" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.6" />
   </ItemGroup>
 
 </Project>

--- a/tests/ServiceStack.Text.Tests.NetCore/Base64Tests.cs
+++ b/tests/ServiceStack.Text.Tests.NetCore/Base64Tests.cs
@@ -1,0 +1,38 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ServiceStack.Text.Tests.NetCore
+{
+    [TestFixture]
+    public class Base64Tests
+    {
+        class Mock { public byte[] Value { get; set; } }
+
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(3)]
+        [TestCase(10)]
+        [TestCase(30)]
+        [TestCase(4096)]
+        [TestCase(4097)]
+        [TestCase(4098)]
+        [TestCase(4099)]
+        [TestCase(4100)]
+        public void CanDeserializeJsonWithBase64ByteArray(int size)
+        {
+            var bytes = new byte[size];
+            new Random(1).NextBytes(bytes);
+            var base64 = Convert.ToBase64String(bytes);
+            var json1 = $"{{\"Value\":\"{base64}\"}}";
+            var mock1 = JsonSerializer.DeserializeFromString<Mock>(json1);
+            CollectionAssert.AreEqual(bytes, mock1.Value);
+            var csvBytes = string.Join(",", bytes.Select(b => b.ToString()));
+            var json2 = $"{{\"Value\":[{csvBytes}]}}";
+            var mock2 = JsonSerializer.DeserializeFromString<Mock>(json2);
+            CollectionAssert.AreEqual(bytes, mock2.Value);
+        }
+    }
+}

--- a/tests/ServiceStack.Text.Tests.NetCore/ServiceStack.Text.Tests.NetCore.csproj
+++ b/tests/ServiceStack.Text.Tests.NetCore/ServiceStack.Text.Tests.NetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
- upgrade netstandard1.6 -> netstandard2.1
- support deserializing base64 byte[]'s
- version 3.8.0
- fix generic warning
